### PR TITLE
Allow user-defined key count

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ g++ -std=c++17 -O2 main.cpp -o main
 
 ## Running
 
-Execute the generated binary to see the metrics for each dataset:
+Execute the generated binary and enter the desired number of keys when prompted.
+The program will then show metrics for random, sequential and clustered datasets:
 
 ```bash
 ./main

--- a/main.cpp
+++ b/main.cpp
@@ -172,7 +172,13 @@ void printMetrics(const std::string& title, const Metrics& m) {
 
 int main() {
     const size_t tableSize = 8192; // power of two
-    const size_t numKeys = 5000;
+
+    size_t numKeys = 0;
+    std::cout << "Enter number of keys: ";
+    if (!(std::cin >> numKeys) || numKeys == 0) {
+        std::cerr << "Invalid number of keys" << std::endl;
+        return 1;
+    }
 
     std::mt19937 rng(42);
     std::uniform_int_distribution<uint32_t> dist(0, 1u << 30);


### PR DESCRIPTION
## Summary
- prompt for number of keys at runtime
- keep random/sequential/clustered dataset tests
- update README with new instructions

## Testing
- `g++ -std=c++17 -O2 main.cpp -o main && ./main <<EOF
1000
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685798a001c48322ba404bef95d5b40b