### PR TITLE
Add dynamic prime-sized resizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+main


### PR DESCRIPTION
## Summary
- implement dynamic resizing for the hash table
- change Fibonacci hashing to support non power-of-two sizes
- start with small prime capacity and grow when load factor > 0.7
- ignore compiled binary in git

## Testing
- `g++ -std=c++17 -O2 main.cpp -o main`

------
https://chatgpt.com/codex/tasks/task_e_68579c2b70f48322b76f464efd08fb58